### PR TITLE
Add Jira adapter using Atlassian CLI (acli)

### DIFF
--- a/docs/examples/jira-adapter.md
+++ b/docs/examples/jira-adapter.md
@@ -1,0 +1,266 @@
+# Jira Adapter for Choo
+
+The Jira adapter enables choo to orchestrate AI agents using Atlassian Jira as the ticket system backend.
+
+## Prerequisites
+
+1. **Install ACLI** - Atlassian's official command-line tool:
+   ```bash
+   # See https://developer.atlassian.com/cloud/acli/
+   # Installation instructions vary by platform
+   ```
+
+2. **Authenticate with Jira**:
+   ```bash
+   # Interactive authentication (recommended)
+   acli jira auth login --web
+   
+   # OR with API token
+   acli jira auth login --site "mycompany.atlassian.net" --email "user@example.com" --token
+   
+   # Verify authentication
+   acli jira auth status
+   ```
+
+3. **Create agent label** in your Jira project (e.g., "agent-ready")
+
+## Configuration
+
+### Minimal Configuration
+
+```yaml
+ticket_system:
+  type: jira-acli
+  config:
+    project: PROJ              # Your Jira project key
+    agent_label: agent-ready   # Label to mark agent-eligible issues
+
+stations:
+  - backlog
+  - done
+
+trains:
+  - name: dev-agent
+    from_station: backlog
+    to_station: done
+    cli: claude
+```
+
+### Complete Configuration
+
+```yaml
+ticket_system:
+  type: jira-acli
+  config:
+    project: PROJ
+    agent_label: agent-ready
+    claim_method: assignee     # Optional: "assignee" (default) or "label"
+    
+    # Optional: Map choo station names to Jira status names
+    status_mapping:
+      backlog: "To Do"
+      in-progress: "In Progress"
+      done: "Done"
+
+stations:
+  - backlog
+  - in-progress
+  - done
+
+trains:
+  - name: code-writer
+    from_station: backlog
+    to_station: in-progress
+    cli: claude
+```
+
+See [jira-config.yml](jira-config.yml) for a complete example.
+
+## Configuration Options
+
+### Required Fields
+
+- **`project`** (string): Jira project key (e.g., "PROJ", "TEAM")
+- **`agent_label`** (string): Label used to mark issues ready for agents
+
+### Optional Fields
+
+- **`claim_method`** (string): How agents claim work
+  - `"assignee"` (default): Assign issue to agent user (@me)
+  - `"label"`: Add "in-progress" label to issue
+
+- **`status_mapping`** (dict): Map choo station names to Jira status names
+  - Useful when your Jira statuses have different names than your stations
+  - Example: `backlog: "To Do"` maps station "backlog" to status "To Do"
+
+## How It Works
+
+### Workflow Stages (Stations)
+
+Choo stations map directly to Jira issue statuses:
+- Station "backlog" → Jira status "Backlog" (or use `status_mapping` to customize)
+- Station "done" → Jira status "Done"
+
+### Agent Work Filtering
+
+Agents only see issues that match ALL of:
+1. **Project**: Issue belongs to configured project
+2. **Status**: Issue status matches agent's `from_station`
+3. **Label**: Issue has the `agent_label` label
+4. **Unclaimed**: Issue is not already assigned (if using assignee claim method)
+
+This allows humans and agents to coexist in the same Jira statuses!
+
+### Example Workflow
+
+1. **Human** creates Jira issue with status "Backlog"
+2. **Human** adds "agent-ready" label when ready for AI
+3. **Agent** sees issue in `choo work list` (matches project + status + label + unclaimed)
+4. **Agent** runs `choo work start PROJ-123` (assigns to @me)
+5. **Agent** works on the issue
+6. **Agent** runs `choo work complete PROJ-123` (transitions to next status)
+7. **Human** reviews and continues workflow
+
+## JQL Query Examples
+
+When listing issues, choo builds JQL queries like:
+
+```jql
+project = PROJ AND status = "Backlog" AND labels = "agent-ready" AND assignee is EMPTY
+```
+
+## Commands
+
+Agents interact with Jira via choo commands:
+
+```bash
+# List available work at a station
+choo work list backlog
+
+# View issue details
+choo work read PROJ-123
+
+# Claim an issue
+choo work start PROJ-123
+
+# Complete work (move to next station)
+choo work complete PROJ-123
+
+# Add a comment
+choo work comment PROJ-123 "Implemented feature X"
+```
+
+## Claim Methods
+
+### Assignee (Default)
+
+Issues are claimed by assigning them to the agent user:
+- **Claim**: `acli jira workitem assign --key PROJ-123 --assignee @me`
+- **Unclaim**: `acli jira workitem assign --key PROJ-123 --remove-assignee`
+- **Filter**: JQL includes `AND assignee is EMPTY`
+
+### Label
+
+Issues are claimed by adding an "in-progress" label:
+- **Claim**: `acli jira workitem edit --key PROJ-123 --add-label in-progress`
+- **Unclaim**: `acli jira workitem edit --key PROJ-123 --remove-label in-progress`
+- **Filter**: JQL includes `AND labels not in ("in-progress")`
+
+## Status Mapping
+
+If your Jira statuses don't match your station names, use `status_mapping`:
+
+```yaml
+ticket_system:
+  type: jira-acli
+  config:
+    project: PROJ
+    agent_label: agent-ready
+    status_mapping:
+      todo: "To Do"           # Station "todo" → Status "To Do"
+      wip: "In Progress"      # Station "wip" → Status "In Progress"
+      qa: "QA Testing"        # Station "qa" → Status "QA Testing"
+      shipped: "Completed"    # Station "shipped" → Status "Completed"
+
+stations:
+  - todo
+  - wip
+  - qa
+  - shipped
+```
+
+## Troubleshooting
+
+### Authentication Issues
+
+```bash
+# Check authentication status
+acli jira auth status
+
+# Re-authenticate
+acli jira auth login --web
+```
+
+### Test ACLI Connection
+
+```bash
+# List projects
+acli jira project list --json
+
+# Search for issues
+acli jira workitem search --jql "project = MYPROJ" --limit 5
+
+# View specific issue
+acli jira workitem view PROJ-123
+```
+
+### Invalid Transitions
+
+If an agent tries to transition an issue to an invalid status for its issue type:
+- ACLI will return an error
+- Check your Jira workflow configuration
+- Ensure the transition is valid for the issue type (Story, Bug, Task, etc.)
+
+### No Issues Found
+
+If `choo work list` shows no issues:
+1. Verify issues exist with the correct status in Jira
+2. Confirm issues have the `agent_label` label
+3. Check issues are not already assigned (if using assignee claim method)
+4. Test the JQL query directly in Jira:
+   ```jql
+   project = MYPROJ AND status = "Backlog" AND labels = "agent-ready" AND assignee is EMPTY
+   ```
+
+## Limitations & Future Enhancements
+
+### Current Limitations (Phase 1)
+
+- Single Jira site support only (uses active ACLI session)
+- Single project per configuration
+- Label-based filtering only (no component/JQL filters)
+- No workflow transition validation
+
+### Future Enhancements (Phase 2+)
+
+- Multi-site support with automatic switching
+- Multi-project support
+- Advanced filtering (components, custom JQL)
+- Sprint integration
+- Epic/hierarchy support
+- Workflow transition validation
+- Custom field mapping
+
+## Architecture
+
+The Jira adapter follows choo's adapter pattern:
+- **Adapter**: `JiraAcliAdapter` - Implements `TicketSystemAdapter` interface
+- **CLI Integration**: Uses `acli jira` commands via subprocess
+- **Authentication**: Relies on ACLI's persistent authentication
+- **State**: Stateless - Jira is the source of truth
+
+## See Also
+
+- [ACLI Documentation](https://developer.atlassian.com/cloud/acli/)
+- [Jira JQL Reference](https://support.atlassian.com/jira-software-cloud/docs/use-advanced-search-with-jira-query-language-jql/)
+- [Example Configuration](jira-config.yml)

--- a/docs/examples/jira-config.yml
+++ b/docs/examples/jira-config.yml
@@ -1,0 +1,65 @@
+# Example Jira Configuration for Choo
+
+# This example shows how to configure choo to work with Jira using the acli CLI.
+
+# Prerequisites:
+# 1. Install acli: https://developer.atlassian.com/cloud/acli/
+# 2. Authenticate: acli jira auth login --web
+# 3. Create an "agent-ready" label in your Jira project
+
+ticket_system:
+  type: jira-acli
+  config:
+    # Required: Jira project key (e.g., "PROJ", "TEAM", "DEV")
+    project: MYPROJ
+    
+    # Required: Label to identify issues that agents should work on
+    # Humans add this label when an issue is ready for AI processing
+    agent_label: agent-ready
+    
+    # Optional: How agents claim work (default: assignee)
+    # - assignee: Assign issue to agent user (@me)
+    # - label: Add "in-progress" label to issue
+    claim_method: assignee
+    
+    # Optional: Map choo station names to Jira status names
+    # Use this if your Jira statuses have different names than your stations
+    # status_mapping:
+    #   backlog: "To Do"
+    #   in-progress: "In Progress"
+    #   review: "Code Review"
+    #   testing: "QA Testing"
+    #   done: "Done"
+
+# Define workflow stages (map to Jira statuses)
+stations:
+  - backlog      # Maps to "Backlog" status in Jira (or use status_mapping)
+  - in-progress  # Maps to "In Progress" status
+  - testing      # Maps to "Testing" status
+  - review       # Maps to "Review" status (human-only station)
+  - done         # Maps to "Done" status
+
+# Configure AI agents (trains) that move work between stations
+trains:
+  - name: code-writer
+    from_station: backlog
+    to_station: testing
+    cli: claude
+    # This agent picks up issues with status="Backlog" AND labels="agent-ready"
+    # It works on them, then transitions them to status="Testing"
+
+  - name: test-runner
+    from_station: testing
+    to_station: review
+    cli: claude
+    # This agent picks up issues with status="Testing" AND labels="agent-ready"
+    # After testing, it moves them to "Review" for human review
+
+# Workflow:
+# 1. Human creates Jira issue with status "Backlog"
+# 2. When ready for AI → Human adds "agent-ready" label
+# 3. code-writer agent picks it up (claims via assignee)
+# 4. Agent works on it, transitions to "Testing"
+# 5. test-runner picks it up from "Testing" (if still has agent-ready label)
+# 6. After testing, moves to "Review" for human review
+# 7. Human reviews and manually moves to "Done"

--- a/src/choo/adapters/factory.py
+++ b/src/choo/adapters/factory.py
@@ -2,6 +2,7 @@
 
 from choo.adapters.base import TicketSystemAdapter
 from choo.adapters.github import GitHubProjectAdapter
+from choo.adapters.jira import JiraAcliAdapter
 from choo.config import TicketSystemConfig
 
 
@@ -26,5 +27,7 @@ def create_adapter(config: TicketSystemConfig, verbose: bool = False) -> TicketS
     """
     if config.type == "github-project-gh":
         return GitHubProjectAdapter(config.config, verbose=verbose)
+    elif config.type == "jira-acli":
+        return JiraAcliAdapter(config.config, verbose=verbose)
 
     raise AdapterError(f"Unknown adapter type: {config.type}")

--- a/src/choo/adapters/jira.py
+++ b/src/choo/adapters/jira.py
@@ -1,0 +1,352 @@
+"""Jira adapter using acli CLI."""
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+from typing import Any
+
+from choo.adapters.base import IssueNotFoundError, TicketSystemAdapter
+from choo.models import Issue
+
+
+class JiraAcliAdapter(TicketSystemAdapter):
+    """Adapter for Jira using the acli CLI."""
+
+    def __init__(self, config: dict[str, Any], verbose: bool = False):
+        """Initialize the Jira adapter.
+
+        Args:
+            config: Configuration dictionary with project, agent_label
+            verbose: If True, print acli commands
+        """
+        self.project = config["project"]
+        self.agent_label = config["agent_label"]
+        self.claim_method = config.get("claim_method", "assignee")
+        self.status_mapping = config.get("status_mapping", {})
+        self.verbose = verbose
+
+        # Lazy-loaded cached values
+        self._statuses: list[str] | None = None
+
+    def _run_acli(self, args: list[str]) -> str:
+        """Run an acli CLI command and return output.
+
+        Args:
+            args: Command arguments to pass to acli
+
+        Returns:
+            Command output as string
+
+        Raises:
+            RuntimeError: If acli command fails
+        """
+        cmd = ["acli"] + args
+
+        if self.verbose:
+            timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+            print(f"[{timestamp}] $ acli {' '.join(args)}", file=sys.stderr)
+
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, check=True, timeout=30
+            )
+            return result.stdout
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"acli command failed: {e.stderr}") from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"acli command timed out: {' '.join(cmd)}") from e
+
+    def _parse_workitem(self, item_data: dict[str, Any]) -> Issue:
+        """Parse a Jira work item into an Issue object.
+
+        Args:
+            item_data: Raw item data from acli API
+
+        Returns:
+            Issue object
+        """
+        # Get status from fields
+        status_field = item_data.get("fields", {}).get("status", {})
+        status = status_field.get("name", "Unknown")
+
+        # Get assignee
+        assignee_field = item_data.get("fields", {}).get("assignee")
+        assignee = None
+        if assignee_field:
+            assignee = assignee_field.get("displayName") or assignee_field.get("emailAddress")
+
+        # Get labels
+        labels = item_data.get("fields", {}).get("labels", [])
+
+        return Issue(
+            id=item_data.get("key", ""),
+            title=item_data.get("fields", {}).get("summary", ""),
+            body=item_data.get("fields", {}).get("description"),
+            station=status,
+            url=item_data.get("self"),
+            assignee=assignee,
+            labels=labels,
+        )
+
+    def list_stations(self) -> list[str]:
+        """List all available workflow stations in the project.
+
+        Returns:
+            List of unique status names
+        """
+        if self._statuses is None:
+            # Query all issues in project and extract unique statuses
+            output = self._run_acli(
+                [
+                    "jira",
+                    "workitem",
+                    "search",
+                    "--jql",
+                    f"project = {self.project}",
+                    "--fields",
+                    "status",
+                    "--limit",
+                    "100",
+                    "--json",
+                ]
+            )
+            data = json.loads(output)
+
+            # ACLI returns a list at top level, not a dict with "issues" key
+            if not isinstance(data, list):
+                data = []
+
+            statuses = set()
+            for item in data:
+                status_field = item.get("fields", {}).get("status", {})
+                status = status_field.get("name")
+                if status:
+                    statuses.add(status)
+
+            self._statuses = sorted(statuses)
+
+        return self._statuses
+
+    def list_issues(self, station: str) -> list[Issue]:
+        """List all issues at a specific workflow station.
+
+        Args:
+            station: The workflow stage (status field value)
+
+        Returns:
+            List of issues at that station that are agent-ready and unclaimed
+        """
+        # Map station to status if mapping exists
+        status = self.status_mapping.get(station, station)
+
+        # Build JQL: project + status + agent label + unclaimed
+        jql = f'project = {self.project} AND status = "{status}" AND labels = "{self.agent_label}"'
+
+        if self.claim_method == "assignee":
+            jql += " AND assignee is EMPTY"
+        elif self.claim_method == "label":
+            jql += ' AND labels not in ("in-progress")'
+
+        output = self._run_acli(
+            [
+                "jira",
+                "workitem",
+                "search",
+                "--jql",
+                jql,
+                "--fields",
+                "key,summary,description,status,assignee,labels",
+                "--json",
+            ]
+        )
+        data = json.loads(output)
+
+        # ACLI returns a list at top level, not a dict with "issues" key
+        if not isinstance(data, list):
+            data = []
+
+        issues = []
+        for item in data:
+            try:
+                issue = self._parse_workitem(item)
+                issues.append(issue)
+            except Exception:
+                # Skip items that can't be parsed
+                continue
+
+        return issues
+
+    def get_issue(self, issue_id: str) -> Issue:
+        """Get full details of a specific issue.
+
+        Args:
+            issue_id: The issue key (e.g., "PROJ-123")
+
+        Returns:
+            Issue object with full details
+
+        Raises:
+            IssueNotFoundError: If issue doesn't exist
+        """
+        try:
+            output = self._run_acli(
+                [
+                    "jira",
+                    "workitem",
+                    "view",
+                    issue_id,
+                    "--fields",
+                    "key,summary,description,status,assignee,labels",
+                    "--json",
+                ]
+            )
+            data = json.loads(output)
+            return self._parse_workitem(data)
+
+        except RuntimeError as e:
+            if "not found" in str(e).lower() or "does not exist" in str(e).lower():
+                raise IssueNotFoundError(f"Issue {issue_id} not found")
+            raise
+
+    def claim_issue(self, issue_id: str) -> None:
+        """Claim an issue by assigning it to the current user.
+
+        Args:
+            issue_id: The issue key
+        """
+        if self.claim_method == "assignee":
+            self._run_acli(
+                [
+                    "jira",
+                    "workitem",
+                    "assign",
+                    "--key",
+                    issue_id,
+                    "--assignee",
+                    "@me",
+                ]
+            )
+        elif self.claim_method == "label":
+            # Add "in-progress" label
+            self._run_acli(
+                [
+                    "jira",
+                    "workitem",
+                    "edit",
+                    "--key",
+                    issue_id,
+                    "--add-label",
+                    "in-progress",
+                ]
+            )
+
+    def unclaim_issue(self, issue_id: str) -> None:
+        """Unclaim an issue by removing assignment.
+
+        Args:
+            issue_id: The issue key
+        """
+        if self.claim_method == "assignee":
+            self._run_acli(
+                [
+                    "jira",
+                    "workitem",
+                    "assign",
+                    "--key",
+                    issue_id,
+                    "--remove-assignee",
+                ]
+            )
+        elif self.claim_method == "label":
+            # Remove "in-progress" label
+            self._run_acli(
+                [
+                    "jira",
+                    "workitem",
+                    "edit",
+                    "--key",
+                    issue_id,
+                    "--remove-label",
+                    "in-progress",
+                ]
+            )
+
+    def move_issue(self, issue_id: str, to_station: str) -> None:
+        """Move an issue to a different workflow station.
+
+        Args:
+            issue_id: The issue key
+            to_station: The target status value
+        """
+        # Map station to status if mapping exists
+        status = self.status_mapping.get(to_station, to_station)
+
+        self._run_acli(
+            [
+                "jira",
+                "workitem",
+                "transition",
+                "--key",
+                issue_id,
+                "--status",
+                status,
+                "--yes",
+            ]
+        )
+
+    def get_comments(self, issue_id: str) -> list[dict[str, str]]:
+        """Get all comments for an issue.
+
+        Args:
+            issue_id: The issue key
+
+        Returns:
+            List of comments with author, body, and created_at
+        """
+        output = self._run_acli(
+            [
+                "jira",
+                "workitem",
+                "comment",
+                "list",
+                issue_id,
+                "--json",
+            ]
+        )
+        data = json.loads(output)
+        comments = []
+
+        for comment in data.get("comments", []):
+            author_field = comment.get("author", {})
+            author = author_field.get("displayName") or author_field.get("emailAddress", "unknown")
+
+            comments.append(
+                {
+                    "author": author,
+                    "body": comment.get("body", ""),
+                    "created_at": comment.get("created", ""),
+                }
+            )
+
+        return comments
+
+    def add_comment(self, issue_id: str, message: str) -> None:
+        """Add a comment to an issue.
+
+        Args:
+            issue_id: The issue key
+            message: The comment text
+        """
+        self._run_acli(
+            [
+                "jira",
+                "workitem",
+                "comment",
+                "create",
+                "--key",
+                issue_id,
+                "--body",
+                message,
+            ]
+        )

--- a/src/choo/config.py
+++ b/src/choo/config.py
@@ -24,6 +24,8 @@ class TicketSystemConfig:
         """Validate ticket system configuration."""
         if self.type == "github-project-gh":
             self._validate_github_config()
+        elif self.type == "jira-acli":
+            self._validate_jira_config()
         else:
             raise ConfigError(f"Unknown ticket system type: {self.type}")
 
@@ -41,6 +43,28 @@ class TicketSystemConfig:
             raise ConfigError("ticket_system.config.repo must be a string")
         if not isinstance(self.config["project_number"], int):
             raise ConfigError("ticket_system.config.project_number must be an integer")
+
+        # Validate claim_method if present
+        if "claim_method" in self.config:
+            valid_methods = ["assignee", "label"]
+            if self.config["claim_method"] not in valid_methods:
+                raise ConfigError(
+                    f"Invalid claim_method: {self.config['claim_method']}. "
+                    f"Must be one of: {valid_methods}"
+                )
+
+    def _validate_jira_config(self) -> None:
+        """Validate Jira-specific configuration."""
+        required = ["project", "agent_label"]
+        for field in required:
+            if field not in self.config:
+                raise ConfigError(f"Missing required field in ticket_system.config: {field}")
+
+        # Validate types
+        if not isinstance(self.config["project"], str):
+            raise ConfigError("ticket_system.config.project must be a string")
+        if not isinstance(self.config["agent_label"], str):
+            raise ConfigError("ticket_system.config.agent_label must be a string")
 
         # Validate claim_method if present
         if "claim_method" in self.config:

--- a/src/choo/models.py
+++ b/src/choo/models.py
@@ -1,7 +1,6 @@
 """Data models for choo."""
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
@@ -10,10 +9,10 @@ class Issue:
 
     id: str
     title: str
-    body: Optional[str]
+    body: str | None
     station: str  # Current workflow stage (e.g., "Backlog", "In Progress")
-    url: Optional[str] = None
-    assignee: Optional[str] = None
+    url: str | None = None
+    assignee: str | None = None
     labels: list[str] = None
 
     def __post_init__(self):

--- a/tests/test_jira_adapter.py
+++ b/tests/test_jira_adapter.py
@@ -1,0 +1,371 @@
+"""Tests for Jira ACLI adapter."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from choo.adapters.base import IssueNotFoundError
+from choo.adapters.jira import JiraAcliAdapter
+
+
+@pytest.fixture
+def jira_config():
+    """Minimal Jira configuration."""
+    return {
+        "project": "TEST",
+        "agent_label": "agent-ready",
+        "claim_method": "assignee",
+    }
+
+
+@pytest.fixture
+def jira_adapter(jira_config):
+    """Create a Jira adapter instance."""
+    return JiraAcliAdapter(jira_config)
+
+
+@pytest.fixture
+def sample_jira_issue():
+    """Sample Jira issue data from acli."""
+    return {
+        "key": "TEST-123",
+        "self": "https://test.atlassian.net/rest/api/3/issue/12345",
+        "fields": {
+            "summary": "Test issue",
+            "description": "This is a test issue",
+            "status": {"name": "To Do"},
+            "assignee": None,
+            "labels": ["agent-ready"],
+        },
+    }
+
+
+@pytest.fixture
+def sample_jira_issue_assigned():
+    """Sample assigned Jira issue."""
+    return {
+        "key": "TEST-456",
+        "self": "https://test.atlassian.net/rest/api/3/issue/12346",
+        "fields": {
+            "summary": "Assigned issue",
+            "description": "This is assigned",
+            "status": {"name": "In Progress"},
+            "assignee": {
+                "displayName": "Test User",
+                "emailAddress": "test@example.com",
+            },
+            "labels": ["agent-ready"],
+        },
+    }
+
+
+def test_init_minimal_config(jira_config):
+    """Test initialization with minimal configuration."""
+    adapter = JiraAcliAdapter(jira_config)
+    assert adapter.project == "TEST"
+    assert adapter.agent_label == "agent-ready"
+    assert adapter.claim_method == "assignee"
+    assert adapter.status_mapping == {}
+    assert adapter.verbose is False
+
+
+def test_init_with_status_mapping():
+    """Test initialization with status mapping."""
+    config = {
+        "project": "TEST",
+        "agent_label": "agent-ready",
+        "status_mapping": {
+            "backlog": "To Do",
+            "done": "Done",
+        },
+    }
+    adapter = JiraAcliAdapter(config)
+    assert adapter.status_mapping == {"backlog": "To Do", "done": "Done"}
+
+
+def test_parse_workitem(jira_adapter, sample_jira_issue):
+    """Test parsing a Jira work item."""
+    issue = jira_adapter._parse_workitem(sample_jira_issue)
+
+    assert issue.id == "TEST-123"
+    assert issue.title == "Test issue"
+    assert issue.body == "This is a test issue"
+    assert issue.station == "To Do"
+    assert issue.assignee is None
+    assert issue.labels == ["agent-ready"]
+
+
+def test_parse_workitem_with_assignee(jira_adapter, sample_jira_issue_assigned):
+    """Test parsing a Jira work item with assignee."""
+    issue = jira_adapter._parse_workitem(sample_jira_issue_assigned)
+
+    assert issue.id == "TEST-456"
+    assert issue.assignee == "Test User"
+    assert issue.station == "In Progress"
+
+
+@patch("subprocess.run")
+def test_list_stations(mock_run, jira_adapter):
+    """Test listing workflow stations."""
+    mock_result = MagicMock()
+    # ACLI returns a list at top level, not wrapped in "issues"
+    mock_result.stdout = json.dumps([
+        {"fields": {"status": {"name": "To Do"}}},
+        {"fields": {"status": {"name": "In Progress"}}},
+        {"fields": {"status": {"name": "Done"}}},
+        {"fields": {"status": {"name": "To Do"}}},  # Duplicate
+    ])
+    mock_run.return_value = mock_result
+
+    stations = jira_adapter.list_stations()
+
+    assert stations == ["Done", "In Progress", "To Do"]  # Sorted, unique
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert args[0] == "acli"
+    assert "workitem" in args
+    assert "search" in args
+    assert "--jql" in args
+
+
+@patch("subprocess.run")
+def test_list_issues(mock_run, jira_adapter, sample_jira_issue):
+    """Test listing issues at a station."""
+    mock_result = MagicMock()
+    # ACLI returns a list at top level
+    mock_result.stdout = json.dumps([sample_jira_issue])
+    mock_run.return_value = mock_result
+
+    issues = jira_adapter.list_issues("To Do")
+
+    assert len(issues) == 1
+    assert issues[0].id == "TEST-123"
+    assert issues[0].station == "To Do"
+
+    # Check JQL query was built correctly
+    args = mock_run.call_args[0][0]
+    jql_index = args.index("--jql") + 1
+    jql = args[jql_index]
+    assert "project = TEST" in jql
+    assert 'status = "To Do"' in jql
+    assert 'labels = "agent-ready"' in jql
+    assert "assignee is EMPTY" in jql
+
+
+@patch("subprocess.run")
+def test_list_issues_with_status_mapping(mock_run):
+    """Test listing issues with status mapping."""
+    config = {
+        "project": "TEST",
+        "agent_label": "agent-ready",
+        "status_mapping": {"backlog": "To Do"},
+    }
+    adapter = JiraAcliAdapter(config)
+
+    mock_result = MagicMock()
+    mock_result.stdout = json.dumps([])  # ACLI returns list
+    mock_run.return_value = mock_result
+
+    adapter.list_issues("backlog")
+
+    # Should use mapped status "To Do" in JQL
+    args = mock_run.call_args[0][0]
+    jql_index = args.index("--jql") + 1
+    jql = args[jql_index]
+    assert 'status = "To Do"' in jql
+
+
+@patch("subprocess.run")
+def test_get_issue(mock_run, jira_adapter, sample_jira_issue):
+    """Test getting a specific issue."""
+    mock_result = MagicMock()
+    mock_result.stdout = json.dumps(sample_jira_issue)
+    mock_run.return_value = mock_result
+
+    issue = jira_adapter.get_issue("TEST-123")
+
+    assert issue.id == "TEST-123"
+    assert issue.title == "Test issue"
+
+    args = mock_run.call_args[0][0]
+    assert "workitem" in args
+    assert "view" in args
+    assert "TEST-123" in args
+
+
+@patch("subprocess.run")
+def test_get_issue_not_found(mock_run, jira_adapter):
+    """Test getting a non-existent issue."""
+    mock_run.side_effect = RuntimeError("Issue not found")
+
+    with pytest.raises(IssueNotFoundError):
+        jira_adapter.get_issue("TEST-999")
+
+
+@patch("subprocess.run")
+def test_claim_issue_assignee(mock_run, jira_adapter):
+    """Test claiming an issue via assignee."""
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_run.return_value = mock_result
+
+    jira_adapter.claim_issue("TEST-123")
+
+    args = mock_run.call_args[0][0]
+    assert "workitem" in args
+    assert "assign" in args
+    assert "--key" in args
+    assert "TEST-123" in args
+    assert "--assignee" in args
+    assert "@me" in args
+
+
+@patch("subprocess.run")
+def test_claim_issue_label(mock_run):
+    """Test claiming an issue via label."""
+    config = {
+        "project": "TEST",
+        "agent_label": "agent-ready",
+        "claim_method": "label",
+    }
+    adapter = JiraAcliAdapter(config)
+
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_run.return_value = mock_result
+
+    adapter.claim_issue("TEST-123")
+
+    args = mock_run.call_args[0][0]
+    assert "workitem" in args
+    assert "edit" in args
+    assert "--add-label" in args
+    assert "in-progress" in args
+
+
+@patch("subprocess.run")
+def test_unclaim_issue(mock_run, jira_adapter):
+    """Test unclaiming an issue."""
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_run.return_value = mock_result
+
+    jira_adapter.unclaim_issue("TEST-123")
+
+    args = mock_run.call_args[0][0]
+    assert "workitem" in args
+    assert "assign" in args
+    assert "--remove-assignee" in args
+
+
+@patch("subprocess.run")
+def test_move_issue(mock_run, jira_adapter):
+    """Test moving an issue to a different status."""
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_run.return_value = mock_result
+
+    jira_adapter.move_issue("TEST-123", "Done")
+
+    args = mock_run.call_args[0][0]
+    assert "workitem" in args
+    assert "transition" in args
+    assert "--key" in args
+    assert "TEST-123" in args
+    assert "--status" in args
+    assert "Done" in args
+    assert "--yes" in args
+
+
+@patch("subprocess.run")
+def test_move_issue_with_mapping(mock_run):
+    """Test moving an issue with status mapping."""
+    config = {
+        "project": "TEST",
+        "agent_label": "agent-ready",
+        "status_mapping": {"done": "Completed"},
+    }
+    adapter = JiraAcliAdapter(config)
+
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_run.return_value = mock_result
+
+    adapter.move_issue("TEST-123", "done")
+
+    args = mock_run.call_args[0][0]
+    status_index = args.index("--status") + 1
+    assert args[status_index] == "Completed"
+
+
+@patch("subprocess.run")
+def test_get_comments(mock_run, jira_adapter):
+    """Test getting comments for an issue."""
+    mock_result = MagicMock()
+    mock_result.stdout = json.dumps({
+        "comments": [
+            {
+                "author": {"displayName": "Alice"},
+                "body": "First comment",
+                "created": "2024-01-01T10:00:00.000Z",
+            },
+            {
+                "author": {"emailAddress": "bob@example.com"},
+                "body": "Second comment",
+                "created": "2024-01-02T11:00:00.000Z",
+            },
+        ]
+    })
+    mock_run.return_value = mock_result
+
+    comments = jira_adapter.get_comments("TEST-123")
+
+    assert len(comments) == 2
+    assert comments[0]["author"] == "Alice"
+    assert comments[0]["body"] == "First comment"
+    assert comments[1]["author"] == "bob@example.com"
+
+
+@patch("subprocess.run")
+def test_add_comment(mock_run, jira_adapter):
+    """Test adding a comment to an issue."""
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_run.return_value = mock_result
+
+    jira_adapter.add_comment("TEST-123", "This is a comment")
+
+    args = mock_run.call_args[0][0]
+    assert "workitem" in args
+    assert "comment" in args
+    assert "create" in args
+    assert "--key" in args
+    assert "TEST-123" in args
+    assert "--body" in args
+    assert "This is a comment" in args
+
+
+@patch("subprocess.run")
+def test_verbose_mode(mock_run, jira_config):
+    """Test verbose mode prints commands."""
+    adapter = JiraAcliAdapter(jira_config, verbose=True)
+
+    mock_result = MagicMock()
+    mock_result.stdout = json.dumps([])  # ACLI returns list
+    mock_run.return_value = mock_result
+
+    with patch("sys.stderr"):
+        adapter.list_issues("To Do")
+        # Verbose mode should print to stderr
+        # We're just checking it doesn't crash
+
+
+def test_command_timeout(jira_adapter):
+    """Test that commands have a timeout."""
+    with patch("subprocess.run") as mock_run:
+        from subprocess import TimeoutExpired
+        mock_run.side_effect = TimeoutExpired("acli", 30)
+
+        with pytest.raises(RuntimeError, match="timed out"):
+            jira_adapter.list_stations()


### PR DESCRIPTION
## Overview

This PR adds support for Jira as a ticket system backend using the official Atlassian Command Line Interface (acli) tool.

## Features

- **Status-based workflow mapping**: Jira statuses map directly to choo stations
- **Label-based work filtering**: Configurable `agent_label` to mark agent-eligible issues
- **Flexible claim methods**: Support for both assignee and label-based claiming
- **Optional status mapping**: Customize Jira status names to match your stations
- **Minimal configuration**: Only `project` and `agent_label` required
- **Simple authentication**: Uses active ACLI session (no site management needed)

## Implementation

- `JiraAcliAdapter` class implementing `TicketSystemAdapter` interface
- All core methods: list_stations, list_issues, get_issue, claim_issue, unclaim_issue, move_issue, get_comments, add_comment
- Configuration validation for Jira-specific settings
- 18 comprehensive unit tests (all passing)
- Complete documentation with examples

## Architecture Decisions

1. **Status-based mapping** instead of board-column approach - simpler and works universally
2. **Single agent_label** for filtering - non-invasive to existing workflows
3. **Subprocess-based ACLI execution** - leverages existing CLI tool with JSON parsing
4. **Stateless design** - Jira remains the source of truth

## Example Configuration

```yaml
ticket_system:
  type: jira-acli
  config:
    project: MYPROJ
    agent_label: agent-ready
    claim_method: assignee  # optional

stations:
  - backlog
  - in-progress
  - done

trains:
  - name: dev-agent
    from_station: backlog
    to_station: done
    cli: claude
```

## Testing

- ✅ All 52 tests pass (18 new Jira adapter tests + 5 config tests)
- ✅ No linting errors
- ✅ Follows existing adapter pattern
- ✅ Mock-based tests (no external dependencies)

## Documentation

- Complete user guide: `docs/examples/jira-adapter.md`
- Example config: `docs/examples/jira-config.yml`
- Setup instructions, troubleshooting, and workflow examples included

## Usage

Teams can now use choo with Jira by:
1. Installing and authenticating with acli: `acli jira auth login --web`
2. Creating an agent label in their Jira project
3. Configuring `.choo/config.yml` with `type: jira-acli`

This brings the same agent orchestration capabilities to Jira users as GitHub Projects users enjoy!

## Files Changed

```
8 files changed, 1209 insertions(+), 4 deletions(-)
- New: src/choo/adapters/jira.py (352 lines)
- New: tests/test_jira_adapter.py (371 lines)  
- New: docs/examples/jira-adapter.md (266 lines)
- New: docs/examples/jira-config.yml (65 lines)
- Modified: src/choo/adapters/factory.py
- Modified: src/choo/config.py
- Modified: tests/test_config.py
- Modified: src/choo/models.py
```