### PR TITLE
feat: Improve agent output streaming with visual separators

### DIFF
--- a/src/choo/agent_adapters/claude.py
+++ b/src/choo/agent_adapters/claude.py
@@ -54,11 +54,14 @@ class ClaudeAdapter(AgentAdapter):
         # Merge environment variables with current environment
         process_env = {**subprocess.os.environ, **env}
 
-        # Run Claude
+        # Run Claude with streaming output
+        # By not capturing stdout/stderr, output streams directly to console
         result = subprocess.run(
             cmd,
             cwd=working_dir,
             env=process_env,
+            stdout=None,  # Inherit parent's stdout (stream to console)
+            stderr=None,  # Inherit parent's stderr (stream to console)
         )
 
         return result.returncode

--- a/src/choo/agent_adapters/copilot.py
+++ b/src/choo/agent_adapters/copilot.py
@@ -59,11 +59,14 @@ class CopilotAdapter(AgentAdapter):
             **env,
         }
 
-        # Run Copilot
+        # Run Copilot with streaming output
+        # By not capturing stdout/stderr, output streams directly to console
         result = subprocess.run(
             cmd,
             cwd=working_dir,
             env=process_env,
+            stdout=None,  # Inherit parent's stdout (stream to console)
+            stderr=None,  # Inherit parent's stderr (stream to console)
         )
 
         return result.returncode

--- a/src/choo/cli.py
+++ b/src/choo/cli.py
@@ -134,6 +134,10 @@ def train_run(ctx, train_name):
         console.print(f"[dim]From station: {train_config.from_station}[/dim]")
         console.print(f"[dim]To station: {train_config.to_station}[/dim]")
         console.print()
+        
+        # Add visual separator before agent output
+        console.rule(f"[cyan]Agent Output[/cyan]")
+        console.print()
 
         verbose = ctx.obj.get("verbose", False)
         exit_code = agent_adapter.run(
@@ -143,10 +147,15 @@ def train_run(ctx, train_name):
             verbose=verbose,
         )
 
+        # Add visual separator after agent output
+        console.print()
+        console.rule(f"[cyan]End Agent Output[/cyan]")
+        console.print()
+
         if exit_code == 0:
-            console.print(f"\n[green]✓ Train '{train_name}' completed successfully[/green]")
+            console.print(f"[green]✓ Train '{train_name}' completed successfully[/green]")
         else:
-            console.print(f"\n[red]✗ Train '{train_name}' exited with code {exit_code}[/red]")
+            console.print(f"[red]✗ Train '{train_name}' exited with code {exit_code}[/red]")
             raise SystemExit(exit_code)
 
     except (ConfigError, AgentAdapterError) as e:


### PR DESCRIPTION
This PR improves the UX when running trains by adding visual separators around agent output.

## Changes

- **Made streaming explicit**: Added explicit `stdout=None, stderr=None` parameters to both CopilotAdapter and ClaudeAdapter with documentation
- **Visual separators**: Added rich console rules to clearly delineate agent output from choo's messages
- **Improved spacing**: Better layout of status messages before and after agent execution

## How It Works

Agent output already streams live to the console during execution (subprocess.run with inherited file descriptors). This PR makes that behavior explicit and adds visual clarity.

## Output Example

```
Starting train 'dev-agent' (copilot)...
From station: backlog
To station: done

──────────────── Agent Output ────────────────

[live agent output streams here in real-time]

──────────────── End Agent Output ────────────

✓ Train 'dev-agent' completed successfully
```

## Testing

All 62 tests passing. The visual separators use `console.rule()` from rich, which is already a dependency.